### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+Dockerfile


### PR DESCRIPTION
Ignore node_modules in build to prevent issue with COPY or bind mounts
when dependencies already exist on the host's filesystem

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
